### PR TITLE
Fix install without conda

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -18,13 +18,16 @@ C++, you must have Python 3, at least Python version 3.6, a C++ compiler and
 The compiling C++ requires the following development library:
 
 
+    * `MKL <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html>`_
     * `Eigen3 <http://eigen.tuxfamily.org/>`_
 
 You can install these packages on Ubuntu by typing the following command:
 
 .. code-block:: bash
 
-    sudo apt-get install g++ cmake libeigen3-dev
+    sudo apt-add-repository multiverse && sudo apt-get update # MKL is in the multiverse repo.
+    sudo apt-get install g++ cmake libeigen3-dev libmkl-dev
+
 
 You need, also, to install Python libraries before configuring and installing
 this software:
@@ -47,6 +50,7 @@ You can specify, among other things, the following options:
 
     * ``--debug`` to compile the C++ library in Debug mode,
     * ``--eigen-root`` to specify the Eigen3 include directory.
+    * ``--mkl-root`` to specify the MKL root
     * ``--cxx-compiler`` to select the C++ compiler to use
 
 Run the ``python setup.py build --help`` command to view all the options


### PR DESCRIPTION
Hi,

First of all, thank you for your work on this package !

I experienced some issues while installing this package in a environment where conda isn't practical.

This PR fixes those issues:
* the `setup.py` script invoked with the `build` command did not read the `--mkl-root=/path/to/mlk` option, which makes the `cmake` configuration impossible when "mkl" is installed outside of `sys.prefix`.
* `setup.py` invoked with `install` did not reads those options, but expected them to build the cmake arguments, even 
when "cmake"  had already ran.

On a ubuntu 20.04 machine, prepared as follow:
```shell
sudo apt-add-repository multiverse # needed for mkl
sudo apt-get update
sudo apt-get install  g++ cmake libeigen3-dev libmkl-dev

git clone https://github.com/CNES/pangeo-pytide.git
cd pangeo-pytide
git submodule update --init --recursive -q
```

After those small fixes, I was able to install the package by running `setup.py` directly
```
python setup.py build --eigen-root /usr/include/eigen3/ --mkl-root /usr/
python setup.py install
```

(I've also update the associated doc.)

I hope this helps,
best regards,

evomassiny